### PR TITLE
fix: improve error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2706,29 +2706,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "argument-vector": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/argument-vector/-/argument-vector-1.0.2.tgz",
-      "integrity": "sha1-3HgGBBCoy4BOnZg7dUCnoCew0bc=",
-      "requires": {
-        "debug": "^2.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "argv-formatter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
@@ -3400,7 +3377,8 @@
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA="
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true
     },
     "chokidar": {
       "version": "3.3.1",
@@ -8009,7 +7987,8 @@
     "lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM="
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "dev": true
     },
     "lazystream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,9 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "argument-vector": "1.0.2",
-    "check-more-types": "2.24.0",
     "debug": "4.1.1",
     "ecstatic": "4.1.2",
-    "got": "9.6.0",
-    "lazy-ass": "1.6.0"
+    "got": "9.6.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -205,13 +205,15 @@ module.exports = {
         }
       }
 
+      const buildUtils = arg.utils.build
+
       await postBuild({
         fullPublishFolder,
         record,
         spec,
         group,
         tag,
-        buildUtils: arg.utils.build,
+        buildUtils,
       })
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,6 @@ const ecstatic = require('ecstatic')
 const http = require('http')
 const debug = require('debug')('netlify-plugin-cypress')
 const debugVerbose = require('debug')('netlify-plugin-cypress:verbose')
-const la = require('lazy-ass')
-const is = require('check-more-types')
 const { ping } = require('./utils')
 
 function serveFolder (folder, port) {
@@ -33,7 +31,7 @@ function startServerMaybe (run, options = {}) {
   }
 }
 
-async function waitOnMaybe (failPlugin, options = {}) {
+async function waitOnMaybe (buildUtils, options = {}) {
   const waitOnUrl = options['wait-on']
   if (!waitOnUrl) {
     debug('no wait-on defined')
@@ -56,7 +54,7 @@ async function waitOnMaybe (failPlugin, options = {}) {
   } catch (err) {
     debug('pinging %s for %d ms failed', waitOnUrl, waitTimeoutMs)
     debug(err)
-    failPlugin(`Pinging ${waitOnUrl} for ${waitTimeoutMs} failed`, { error: err })
+    return buildUtils.failBuild(`Pinging ${waitOnUrl} for ${waitTimeoutMs} failed`, { error: err })
   }
 }
 
@@ -95,13 +93,13 @@ async function onInit(arg) {
   await arg.utils.run('cypress', ['install'], runOptions)
 }
 
-const processCypressResults = (results, failPlugin) => {
+const processCypressResults = (results, buildUtils) => {
   if (results.failures) {
     // Cypress failed without even running the tests
     console.error('Problem running Cypress')
     console.error(results.message)
 
-    return failPlugin('Problem running Cypress', {
+    return buildUtils.failPlugin('Problem running Cypress', {
       error: new Error(results.message)
     })
   }
@@ -115,13 +113,13 @@ const processCypressResults = (results, failPlugin) => {
 
   // results.totalFailed gives total number of failed tests
   if (results.totalFailed) {
-    return failPlugin('Failed Cypress tests', {
+    return buildUtils.failBuild('Failed Cypress tests', {
       error: new Error(`${results.totalFailed} test(s) failed`)
     })
   }
 }
 
-async function postBuild({ fullPublishFolder, record, spec, group, tag, failPlugin }) {
+async function postBuild({ fullPublishFolder, record, spec, group, tag, buildUtils }) {
   const port = 8080
   const server = serveFolder(fullPublishFolder, port)
   debug('local server listening on port %d', port)
@@ -140,7 +138,7 @@ async function postBuild({ fullPublishFolder, record, spec, group, tag, failPlug
     })
   })
 
-  processCypressResults(results, failPlugin)
+  processCypressResults(results, buildUtils)
 }
 
 const hasRecordKey = () => typeof process.env.CYPRESS_RECORD_KEY === 'string'
@@ -155,11 +153,8 @@ module.exports = {
         return
       }
 
-      const failPlugin = arg.utils && arg.utils.build && arg.utils.build.failPlugin
-      la(is.fn(failPlugin), 'expected failPlugin function inside', arg.utils)
-
       const closeServer = startServerMaybe(arg.utils.run, preBuildInputs)
-      await waitOnMaybe(failPlugin, preBuildInputs)
+      await waitOnMaybe(arg.utils.build, preBuildInputs)
 
       const baseUrl = preBuildInputs['wait-on']
       const record = hasRecordKey() && Boolean(preBuildInputs.record)
@@ -183,7 +178,7 @@ module.exports = {
         closeServer()
       }
 
-      processCypressResults(results, failPlugin)
+      processCypressResults(results, args.utils.build)
     },
 
     onPostBuild: async (arg) => {
@@ -210,16 +205,13 @@ module.exports = {
         }
       }
 
-      const failPlugin = arg.utils && arg.utils.build && arg.utils.build.failPlugin
-      la(is.fn(failPlugin), 'expected failPlugin function inside', arg.utils)
-
       await postBuild({
         fullPublishFolder,
         record,
         spec,
         group,
         tag,
-        failPlugin
+        buildUtils: arg.utils.build,
       })
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,7 @@ module.exports = {
         closeServer()
       }
 
-      processCypressResults(results, args.utils.build)
+      processCypressResults(results, arg.utils.build)
     },
 
     onPostBuild: async (arg) => {


### PR DESCRIPTION
Netlify plugins can choose to notify errors with either:
  - `failPlugin()`: stops the plugin but not the whole build
  - `failBuild()`: stops the whole build

This PR uses `failPlugin()` for error with the Cypress setup itself, and `failBuild()` when the Cypress tests fail (including the ping).

`utils.build` is guaranteed to exist, so this PR also removes that additional check. This is turns allows removing few dependencies.