### PR TITLE
fix: Add `engines.node` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=10"
+  },
   "devDependencies": {
     "cypress": "4.7.0",
     "netlify-cli": "2.47.0",


### PR DESCRIPTION
An `engines.node` field in `package.json` can be added in Build plugins. 
When present, a nice error message will be shown to users with old Node.js versions.

A Node 8 user encountered this problem with `netlify-plugin-cypress`. This plugin requires Node 10 due to the [`got` dependency](https://github.com/sindresorhus/got/blob/5c74084fe49fe69e3e12e059d6adf46def2af764/package.json#L10).