### PR TITLE
fix: Fail build if Cypress runs into a problem

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ const processCypressResults = (results, buildUtils) => {
     console.error('Problem running Cypress')
     console.error(results.message)
 
-    return buildUtils.failPlugin('Problem running Cypress', {
+    return buildUtils.failBuild('Problem running Cypress', {
       error: new Error(results.message)
     })
   }


### PR DESCRIPTION
Currently the Cypress plugin allows the build to continue if Cypress itself fails to run. This PR fails the build in this case.