### PR TITLE
feat: add skip=true flag to postBuild tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,11 @@ How to [code a plugin](https://github.com/netlify/build/blob/master/docs/creatin
 
 End-to-end tests are in folder [tests](tests) and they use this [plugin locally](https://github.com/netlify/build/blob/master/README.md#using-a-local-plugin) and build each subfolder using Netlify CLI on CircleCI. You can find the test recordings at [Cypress Dashboard](https://dashboard.cypress.io/projects/ixroqc/)
 
+To run locally:
+
+- `npx netlify link` once
+- from every subfolder of `tests` execute `npm run build`
+
 ### Authentication (local)
 
 - use `netlify-cli` to authenticate locally. It will also create a local site and store its ID in `.netlify` folder (ignored by `git`)

--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ Parameters you can place into `preBuild` inputs: `start`, `wait-on`, `wait-on-ti
 
 See [netlify-plugin-prebuild-example](https://github.com/cypress-io/netlify-plugin-prebuild-example) repo
 
+### skipping tests
+
+If you are testing the site before building it, you probably want to skip testing it after the build. See [tests/test-prebuild-only](./tests/test-prebuild-only/netlify.toml):
+
+```toml
+[[plugins]]
+  package = "netlify-plugin-cypress"
+  [plugins.inputs]
+    skip = true
+```
+
 ### parallelization
 
 Running tests in parallel **is not supported** because Netlify plugin system runs on a single machine. Thus you can record the tests on Cypress Dashboard, but not run tests in parallel. If Netlify expands its build offering by allowing multiple build machines, we could take advantage of it and run tests in parallel.

--- a/circle.yml
+++ b/circle.yml
@@ -76,6 +76,19 @@ jobs:
           environment:
             DEBUG: netlify-plugin-cypress
 
+  'test-prebuild-only':
+    executor: cypress/base-12-14-0
+    steps:
+      # all dependencies were installed in previous job
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Netlify Build 🏗
+          command: npx netlify build
+          working_directory: tests/test-prebuild-only
+          environment:
+            DEBUG: netlify-plugin-cypress
+
   routing:
     executor: cypress/base-12-14-0
     steps:
@@ -107,6 +120,9 @@ workflows:
       - 'test-twice':
           requires:
             - cypress/install
+      - 'test-prebuild-only':
+          requires:
+            - cypress/install
       - routing:
           requires:
             - cypress/install
@@ -117,6 +133,7 @@ workflows:
             - 'recommended test'
             - 'recording test'
             - 'test-twice'
+            - 'test-prebuild-only'
             - 'routing'
           filters:
             branches:

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,9 @@ inputs:
   - name: group
   - name: tag
   - name: spa
+  # by default run the tests
+  - name: skip
+    default: false
 
   # tells the plugin how to start the server using custom command
   # and waiting for an url, record to the dashboard, tag, etc

--- a/src/index.js
+++ b/src/index.js
@@ -255,6 +255,12 @@ module.exports = {
       debugVerbose('postBuild arg %o', arg)
       debug('cypress plugin postBuild inputs %o', arg.inputs)
 
+      const skipTests = Boolean(arg.inputs.skip)
+      if (skipTests) {
+        console.log('Skipping tests because skip=true')
+        return
+      }
+
       const fullPublishFolder = arg.constants.PUBLISH_DIR
       debug('folder to publish is "%s"', fullPublishFolder)
 

--- a/tests/test-prebuild-only/cypress.json
+++ b/tests/test-prebuild-only/cypress.json
@@ -1,0 +1,7 @@
+{
+  "pluginsFile": false,
+  "supportFile": false,
+  "fixturesFolder": false,
+  "baseUrl": "http://localhost:5000",
+  "projectId": "ixroqc"
+}

--- a/tests/test-prebuild-only/cypress/integration/spec.js
+++ b/tests/test-prebuild-only/cypress/integration/spec.js
@@ -1,0 +1,5 @@
+/// <reference types="cypress" />
+it('loads page', () => {
+  cy.visit('/')
+  cy.contains('Placeholder').should('be.visible')
+})

--- a/tests/test-prebuild-only/netlify.toml
+++ b/tests/test-prebuild-only/netlify.toml
@@ -1,0 +1,28 @@
+[build]
+command = "echo 'Netlify build command ...'"
+publish = "public"
+
+[build.environment]
+# cache Cypress binary in local "node_modules" folder
+# so Netlify caches it
+CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"
+# set TERM variable for terminal output
+TERM = "xterm"
+
+[[plugins]]
+  # local Cypress plugin will test our site after it is built
+  # in production, please use: package = "netlify-plugin-cypress"
+  package = "../../"
+
+  # run Cypress tests once on the site before it is built
+  # and do not run the tests after it was built
+
+  # let's run tests against development server
+  [plugins.inputs.preBuild]
+    start = 'npx serve public'
+    wait-on = 'http://localhost:5000'
+    wait-on-timeout = '30' # seconds
+
+  # and skip tests after building it
+  [plugins.inputs]
+    skip = true

--- a/tests/test-prebuild-only/public/index.html
+++ b/tests/test-prebuild-only/public/index.html
@@ -1,0 +1,1 @@
+<body>Placeholder</body>


### PR DESCRIPTION
- closes #96

Adds a parameter to skip the tests postBuild
```
[plugins.inputs]
  skip = true
```

See tests/test-prebuild-only job