### PR TITLE
feat: output summary from the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ Name | Description
 
 Set environment variable `DEBUG=netlify-plugin-cypress` to see the debug logs. To see even more information, set `DEBUG=netlify-plugin-cypress,netlify-plugin-cypress:verbose`
 
+**Warning:** be careful with verbose logging, since it can print all environment variables passed to the plugin, including tokens, API keys, and other secrets.
+
 ## Common problems
 
 <details>

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -3,3 +3,9 @@ it('loads page', () => {
   cy.visit('/')
   cy.contains('Placeholder').should('be.visible')
 })
+
+it.skip('skips this test on purpose', () => {
+  expect(false).to.be.true
+})
+
+it('has not test yet')

--- a/package-lock.json
+++ b/package-lock.json
@@ -9313,8 +9313,7 @@
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-      "dev": true
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
     },
     "commondir": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "license": "ISC",
   "dependencies": {
+    "common-tags": "1.8.0",
     "debug": "4.1.1",
     "got": "10.7.0",
     "local-web-server": "^4.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -160,6 +160,7 @@ const processCypressResults = (results, errorCallback) => {
       `Expected error callback to be a function, it was ${typeof errorCallback}`,
     )
   }
+
   if (results.failures) {
     // Cypress failed without even running the tests
     console.error('Problem running Cypress')
@@ -363,10 +364,16 @@ module.exports = {
     debug('onSuccessInputs %s %o', typeof onSuccessInputs, onSuccessInputs)
 
     const errorCallback = utils.build.failPlugin.bind(utils.build)
+    const summaryCallback = utils.status.show.bind(utils.status)
 
     if (!deployPrimeUrl) {
       return errorCallback('Missing DEPLOY_PRIME_URL')
     }
+
+    summaryCallback({
+      summary: `Testing url ${deployPrimeUrl}`,
+      text: 'Lots of stuff to show here 202 https://on.cypress.io',
+    })
 
     const browser = arg.inputs.browser || DEFAULT_BROWSER
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const debug = require('debug')('netlify-plugin-cypress')
 const debugVerbose = require('debug')('netlify-plugin-cypress:verbose')
 const { ping, getBrowserPath, serveFolder } = require('./utils')
 
+const PLUGIN_NAME = 'netlify-plugin-cypress'
 const DEFAULT_BROWSER = 'electron'
 
 function startServerMaybe(run, options = {}) {
@@ -371,6 +372,7 @@ module.exports = {
     }
 
     summaryCallback({
+      title: PLUGIN_NAME,
       summary: `Testing url ${deployPrimeUrl}`,
       text: 'Lots of stuff to show here 202 https://on.cypress.io',
     })

--- a/src/index.js
+++ b/src/index.js
@@ -205,7 +205,13 @@ const processCypressResults = (results, errorCallback, summaryCallback) => {
   }
   summaryCallback({
     title: PLUGIN_NAME,
-    summary: `tests: ✅ ${results.totalPassed} 🔥 ${results.totalFailed}`,
+    summary: [
+      'tests:',
+      `✅ ${results.totalPassed}`,
+      `🔥 ${results.totalFailed}`,
+      `⭕️ ${results.totalPending}`,
+      `🚫 ${results.totalSkipped}`,
+    ].join(' '),
     text,
   })
 


### PR DESCRIPTION
- closes #122
- uses https://docs.netlify.com/configure-builds/build-plugins/create-plugins/#logging

![plugin-summary](https://user-images.githubusercontent.com/2212006/107574696-f8600c80-6bbc-11eb-90a8-10ba31331dc3.gif)

If there is run URL, then it will be in the details section, but unfortunately, it won't be a link, just a plain text