### PR TITLE
fix: use dashboard url markdown syntax

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,5 @@
   "pluginsFile": false,
   "fixturesFolder": false,
   "baseUrl": "http://localhost:5000",
-  "projectId": "vghvje"
+  "projectId": "ixroqc"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "supportFile": false,
   "pluginsFile": false,
   "fixturesFolder": false,
-  "baseUrl": "http://localhost:5000"
+  "baseUrl": "http://localhost:5000",
+  "projectId": "vghvje"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -194,23 +194,24 @@ const processCypressResults = (results, errorCallback, summaryCallback) => {
     }
   })
 
+  // Note: text looks nice with double space after the emoji
   const summary = [
     'tests:',
-    `✅ ${results.totalPassed}`,
-    `🔥 ${results.totalFailed}`,
-    `⭕️ ${results.totalPending}`,
-    `🚫 ${results.totalSkipped}`,
+    `✅  ${results.totalPassed}`,
+    `🔥  ${results.totalFailed}`,
+    `⭕️  ${results.totalPending}`,
+    `🚫  ${results.totalSkipped}`,
   ]
 
   let text = stripIndent`
-    ✅ Passed tests: ${results.totalPassed}
-    🔥 Failed tests: ${results.totalFailed}
-    ⭕️ Pending tests: ${results.totalPending}
-    🚫 Skipped tests: ${results.totalSkipped}
+    ✅  Passed tests: ${results.totalPassed}
+    🔥  Failed tests: ${results.totalFailed}
+    ⭕️  Pending tests: ${results.totalPending}
+    🚫  Skipped tests: ${results.totalSkipped}
   `
   if (results.runUrl) {
     summary.push(`🔗 [dashboard run](${results.runUrl})`)
-    text += `\n🔗 Dashboard url: [${results.runUrl}](${results.runUrl})`
+    text += `\n🔗 Cypress Dashboard url: [${results.runUrl}](${results.runUrl})`
   }
   summaryCallback({
     title: PLUGIN_NAME,

--- a/src/index.js
+++ b/src/index.js
@@ -194,6 +194,14 @@ const processCypressResults = (results, errorCallback, summaryCallback) => {
     }
   })
 
+  const summary = [
+    'tests:',
+    `✅ ${results.totalPassed}`,
+    `🔥 ${results.totalFailed}`,
+    `⭕️ ${results.totalPending}`,
+    `🚫 ${results.totalSkipped}`,
+  ]
+
   let text = stripIndent`
     ✅ Passed tests: ${results.totalPassed}
     🔥 Failed tests: ${results.totalFailed}
@@ -201,17 +209,12 @@ const processCypressResults = (results, errorCallback, summaryCallback) => {
     🚫 Skipped tests: ${results.totalSkipped}
   `
   if (results.runUrl) {
-    text += `\n🔗 Dashboard url: ${results.runUrl}`
+    summary.push(`🔗 [dashboard run](${results.runUrl})`)
+    text += `\n🔗 Dashboard url: [${results.runUrl}](${results.runUrl})`
   }
   summaryCallback({
     title: PLUGIN_NAME,
-    summary: [
-      'tests:',
-      `✅ ${results.totalPassed}`,
-      `🔥 ${results.totalFailed}`,
-      `⭕️ ${results.totalPending}`,
-      `🚫 ${results.totalSkipped}`,
-    ].join(' '),
+    summary: summary.join(' '),
     text,
   })
 


### PR DESCRIPTION
- closes #124 
- uses Markdown syntax to put the Dashboard URL in the status text

![markdown-urls](https://user-images.githubusercontent.com/2212006/107657411-2728c200-6c53-11eb-987e-fdf4e2c1983a.gif)
