### PR TITLE
feat: rework test phases to make onSuccess default

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,12 @@ Set environment variable `DEBUG=netlify-plugin-cypress` to see the debug logs. T
   Switch to using Chromium browser that seems to be a bit more reliable. Use <code>browser = "chromium"</code> setting.
 </details>
 
+## Changelog
+
+### v1 to v2
+
+- We have changed the default testing phase. In v1 the tests executed after building the site by default. In v2 the tests run against the deployed URL by default, and you need to enable the testing during `preBuild` or `postBuild` steps.
+
 ## License
 
 This project is licensed under the terms of the [MIT license](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ package = "netlify-plugin-cypress"
 
 See [cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink) for instance.
 
-### Chromium
+### browser
 
-By default all tests run using built-in Electron browser. If you want to use Chromium:
+By default all tests run using Chromium browser. If you want to use Electron:
 
 ```toml
 [build]
@@ -195,7 +195,8 @@ publish = "build"
 [[plugins]]
 package = "netlify-plugin-cypress"
   [plugins.inputs]
-  browser = "chromium"
+  # allowed values: electron, chromium
+  browser = "electron"
 ```
 
 ### testing SPA routes
@@ -293,6 +294,12 @@ Name | Description
 [cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink) | Runs only a subset of all tests before publishing the folder to Netlify
 [bahmutov/eleventyone](https://github.com/bahmutov/eleventyone) | Example used in [Test Sites Deployed To Netlify Using netlify-plugin-cypress](https://glebbahmutov.com/blog/test-netlify/) tutorial
 [gatsby-starter-portfolio-cara](https://github.com/bahmutov/gatsby-starter-portfolio-cara) | A Gatsby site example
+
+## Major upgrades
+
+### v1 to v2
+
+- The default browser has been switched to Chromium. If you want to use the built-in Electron use an explicit option [browser](#browser)
 
 ## Debugging
 

--- a/circle.yml
+++ b/circle.yml
@@ -175,6 +175,8 @@ workflows:
           requires:
             - cypress/install
       - release:
+          # run the release job on all branches
+          # since we might want to release a beta version
           requires:
             - build
             - 'basic test'
@@ -186,8 +188,3 @@ workflows:
             - test-using-chromium
             - test-netlify-dev
             - 'routing'
-          filters:
-            branches:
-              only:
-                - master
-                - beta

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,10 @@ jobs:
     executor:
       name: node/default
       tag: '12'
+    environment:
+      # since we do not need Cypress to publish the NPM package
+      # we can skip the binary download
+      CYPRESS_INSTALL_BINARY: 0
     steps:
       - checkout
       - node/with-cache:
@@ -188,12 +192,13 @@ workflows:
           # since we might want to release a beta version
           requires:
             - build
-            - 'basic test'
-            - 'html-pages'
-            - 'recommended test'
-            - 'recording test'
-            - 'test-twice'
-            - 'test-prebuild-only'
-            - test-using-chromium
-            - test-netlify-dev
-            - 'routing'
+            # temporary while publishing pre-release
+            # - 'basic test'
+            # - 'html-pages'
+            # - 'recommended test'
+            # - 'recording test'
+            # - 'test-twice'
+            # - 'test-prebuild-only'
+            # - test-using-chromium
+            # - test-netlify-dev
+            # - 'routing'

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,16 @@ jobs:
       - node/with-cache:
           steps:
             - run: npm ci
-      - run: npx semantic-release
+      # allow CircleCI to release beta versions
+      # from pull request build jobs
+      - run:
+          name: Semantic release 🚀
+          command: npx semantic-release
+          # by tricking Circle and removing the environment variables
+          environment:
+            CIRCLE_PR_NUMBER:
+            CIRCLE_PULL_REQUEST:
+            CI_PULL_REQUEST:
 
   'basic test':
     executor: cypress/base-12-14-0

--- a/circle.yml
+++ b/circle.yml
@@ -84,7 +84,7 @@ jobs:
           at: ~/
       - run:
           name: Netlify Build 🏗
-          command: npx netlify build
+          command: npm run netlify:build
           working_directory: tests/test-prebuild-only
           environment:
             DEBUG: netlify-plugin-cypress
@@ -110,7 +110,7 @@ jobs:
           at: ~/
       - run:
           name: Netlify Build 🏗
-          command: npx netlify build
+          command: npm run netlify:build
           working_directory: tests/test-netlify-dev
           environment:
             DEBUG: netlify-plugin-cypress

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,26 +1,44 @@
 name: netlify-plugin-cypress
 inputs:
-  # these settings apply during postBuild step
-  # when we are testing the site served from the distribution folder
+  # these settings apply during onSuccess step
+  - name: enable
+    description: Run tests against the preview or production deploy
+    default: true
+
   - name: record
+    description: Record test results to Cypress Dashboard
     default: false
+
   - name: spec
+    description: |
+      Run just the given spec or spec pattern,
+      equivalent to "cypress run --spec ..."
+
   - name: group
+    description: |
+      If recording to Cypress Dashboard,
+      pass the group name with "cypress run --record --group ..."
+
   - name: tag
-  - name: spa
-  # by default run the tests
-  - name: skip
-    default: false
-  # by default the tests run in Electron
-  # but because of the dependency we download Chromium
-  # so you can set "browser = electron"
+    description: |
+      If recording to Cypress Dashboard,
+      pass the tag with "cypress run --record --tag ..."
+
+  # Cypress comes with built-in Electron browser
+  # and this NPM package installs Chromium browser
   - name: browser
-    default: electron
+    description: Allowed values are chromium, electron
+    default: chromium
 
   # tells the plugin how to start the server using custom command
   # and waiting for an url, record to the dashboard, tag, etc
   # see README "testing the site before build"
   - name: preBuild
+    description: Run tests before building the site
 
-  # you can control how the plugin runs the tests after deploy
-  - name: onSuccess
+  # tells the plugin to start a static server during postBuild
+  # and test just the built static site.
+  # see README "testing the site after build"
+  # NOTE: does not execute Netlify API redirects or functions
+  - name: postBuild
+    description: Run tests against the built static site

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,9 +1,16 @@
 name: netlify-plugin-cypress
 inputs:
-  # these settings apply during onSuccess step
+  # by default the Cypress tests run against the deployed URL
+  # and these settings apply during the "onSuccess" step
   - name: enable
     description: Run tests against the preview or production deploy
     default: true
+
+  # Cypress comes with built-in Electron browser
+  # and this NPM package installs Chromium browser
+  - name: browser
+    description: Allowed values are chromium, electron
+    default: chromium
 
   - name: record
     description: Record test results to Cypress Dashboard
@@ -23,12 +30,6 @@ inputs:
     description: |
       If recording to Cypress Dashboard,
       pass the tag with "cypress run --record --tag ..."
-
-  # Cypress comes with built-in Electron browser
-  # and this NPM package installs Chromium browser
-  - name: browser
-    description: Allowed values are chromium, electron
-    default: chromium
 
   # tells the plugin how to start the server using custom command
   # and waiting for an url, record to the dashboard, tag, etc

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,14 +10,15 @@ publish = "public"
 [[plugins]]
   # local Cypress plugin will test our site after it is built
   package = "."
+
+  # run tests after deploying to Netlify
   [plugins.inputs]
-    # browser = "electron"
-    # spec = 'cypress/integration/spec.js'
-  # [plugins.inputs.preBuild]
-  #   start = 'npm start'
-  #   wait-on = 'http://localhost:5000'
-  #   wait-on-timeout = '3' # seconds
-  [plugins.inputs.onSuccess]
-    enable = true
     record = true
     group = 'deployed'
+
+  # run tests after building the site
+  [plugins.inputs.postBuild]
+    enable = true
+    record = true
+    group = 'postBuild'
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10750,6 +10750,12 @@
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
+        "ramda": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+          "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+          "dev": true
+        },
         "shebang-command": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -27076,10 +27082,9 @@
       }
     },
     "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
-      "dev": true
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
     "random-bytes": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "debug": "4.1.1",
     "got": "10.7.0",
     "local-web-server": "^4.2.1",
-    "puppeteer": "^7.0.1"
+    "puppeteer": "^7.0.1",
+    "ramda": "0.27.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,14 @@
     "react-scripts": "3.4.1",
     "semantic-release": "^17.0.4",
     "serve": "11.3.0"
+  },
+  "release": {
+    "branches": [
+      "main",
+      {
+        "name": "prepare-v2",
+        "prerelease": true
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
   },
   "release": {
     "branches": [
-      { "name": "master" },
+      {
+        "name": "master"
+      },
       {
         "name": "prepare-v2",
         "prerelease": true

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "release": {
     "branches": [
-      "main",
+      { "name": "main" },
       {
         "name": "prepare-v2",
         "prerelease": true

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "release": {
     "branches": [
-      { "name": "main" },
+      { "name": "master" },
       {
         "name": "prepare-v2",
         "prerelease": true

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 // @ts-check
 const { stripIndent } = require('common-tags')
+const R = require('ramda')
 const debug = require('debug')('netlify-plugin-cypress')
 const debugVerbose = require('debug')('netlify-plugin-cypress:verbose')
 const { ping, getBrowserPath, serveFolder } = require('./utils')
@@ -278,21 +279,26 @@ const hasRecordKey = () => typeof process.env.CYPRESS_RECORD_KEY === 'string'
 
 module.exports = {
   onPreBuild: async (arg) => {
+    // we need to install everything to be ready
     await install(arg)
     await cypressVerify(arg)
     await cypressInfo(arg)
 
-    debug('cypress plugin preBuild inputs %o', arg.inputs)
-    const preBuildInputs = arg.inputs && arg.inputs.preBuild
-    if (!preBuildInputs) {
-      debug('there are no preBuild inputs')
+    const { inputs, utils } = arg
+
+    const preBuildInputs = inputs.preBuild || {}
+    debug('preBuild inputs %o', preBuildInputs)
+
+    const enablePreBuildTests = Boolean(preBuildInputs.enable)
+    if (!enablePreBuildTests) {
+      debug('Skipping preBuild tests')
       return
     }
 
-    const browser = arg.inputs.browser || DEFAULT_BROWSER
+    const browser = preBuildInputs.browser || DEFAULT_BROWSER
 
-    const closeServer = startServerMaybe(arg.utils.run, preBuildInputs)
-    await waitOnMaybe(arg.utils.build, preBuildInputs)
+    const closeServer = startServerMaybe(utils.run, preBuildInputs)
+    await waitOnMaybe(utils.build, preBuildInputs)
 
     const baseUrl = preBuildInputs['wait-on']
     const record = hasRecordKey() && Boolean(preBuildInputs.record)
@@ -323,47 +329,49 @@ module.exports = {
       closeServer()
     }
 
-    const errorCallback = arg.utils.build.failBuild.bind(arg.utils.build)
-    const summaryCallback = arg.utils.status.show.bind(arg.utils.status)
+    const errorCallback = utils.build.failBuild.bind(utils.build)
+    const summaryCallback = utils.status.show.bind(utils.status)
 
     processCypressResults(results, errorCallback, summaryCallback)
   },
 
-  onPostBuild: async (arg) => {
-    debugVerbose('postBuild arg %o', arg)
-    debug('cypress plugin postBuild inputs %o', arg.inputs)
+  onPostBuild: async ({ inputs, constants, utils }) => {
+    debugVerbose('===postBuild===')
 
-    const skipTests = Boolean(arg.inputs.skip)
-    if (skipTests) {
-      console.log('Skipping tests because skip=true')
+    const postBuildInputs = inputs.postBuild || {}
+    debug('cypress plugin postBuild inputs %o', postBuildInputs)
+
+    const enablePostBuildTests = Boolean(postBuildInputs.enable)
+    if (!enablePostBuildTests) {
+      debug('Skipping postBuild tests')
       return
     }
 
-    const fullPublishFolder = arg.constants.PUBLISH_DIR
+    const fullPublishFolder = constants.PUBLISH_DIR
     debug('folder to publish is "%s"', fullPublishFolder)
 
-    const browser = arg.inputs.browser || DEFAULT_BROWSER
+    const browser = postBuildInputs.browser || DEFAULT_BROWSER
 
     // only if the user wants to record the tests and has set the record key
     // then we should attempt recording
-    const record = hasRecordKey() && Boolean(arg.inputs.record)
+    const record = hasRecordKey() && Boolean(postBuildInputs.record)
 
-    const spec = arg.inputs.spec
+    const spec = postBuildInputs.spec
     let group
     let tag
     if (record) {
-      group = arg.inputs.group || 'postBuild'
+      group = postBuildInputs.group || 'postBuild'
 
-      if (arg.inputs.tag) {
-        tag = arg.inputs.tag
+      if (postBuildInputs.tag) {
+        tag = postBuildInputs.tag
       } else {
         tag = process.env.CONTEXT
       }
     }
-    const spa = arg.inputs.spa
+    const spa = postBuildInputs.spa
 
-    const errorCallback = arg.utils.build.failBuild.bind(arg.utils.build)
-    const summaryCallback = arg.utils.status.show.bind(arg.utils.status)
+    const errorCallback = utils.build.failBuild.bind(utils.build)
+    const summaryCallback = utils.status.show.bind(utils.status)
 
     await postBuild({
       fullPublishFolder,
@@ -382,11 +390,12 @@ module.exports = {
    * Executes after successful Netlify deployment.
    * @param {any} arg
    */
-  onSuccess: async (arg) => {
-    debugVerbose('onSuccess arg %o', arg)
+  onSuccess: async ({ utils, inputs, constants }) => {
+    debugVerbose('onSuccess arg %o', { utils, inputs, constants })
 
-    const { utils, inputs, constants } = arg
-    debug('onSuccess inputs %o', inputs)
+    // extract test run parameters
+    const onSuccessInputs = R.omit(['preBuild', 'postBuild'], inputs || {})
+    debug('onSuccess inputs %o', onSuccessInputs)
 
     const isLocal = constants.IS_LOCAL
     const siteName = process.env.SITE_NAME
@@ -397,16 +406,9 @@ module.exports = {
       isLocal,
     })
 
-    // extract test run parameters
-    const onSuccessInputs = inputs.onSuccess
-    if (!onSuccessInputs) {
-      debug('no onSuccess inputs, skipping testing the deployed url')
-      return
-    }
-
-    const enableTests = Boolean(onSuccessInputs.enable)
-    if (!enableTests) {
-      console.log('Skipping tests because enable=false')
+    const enableOnSuccessTests = Boolean(onSuccessInputs.enable)
+    if (!enableOnSuccessTests) {
+      debug('Skipping onSuccess tests')
       return
     }
 
@@ -419,7 +421,7 @@ module.exports = {
       return errorCallback('Missing DEPLOY_PRIME_URL')
     }
 
-    const browser = arg.inputs.browser || DEFAULT_BROWSER
+    const browser = onSuccessInputs.browser || DEFAULT_BROWSER
 
     // only if the user wants to record the tests and has set the record key
     // then we should attempt recording

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const debugVerbose = require('debug')('netlify-plugin-cypress:verbose')
 const { ping, getBrowserPath, serveFolder } = require('./utils')
 
 const PLUGIN_NAME = 'netlify-plugin-cypress'
-const DEFAULT_BROWSER = 'electron'
+const DEFAULT_BROWSER = 'chromium'
 
 function startServerMaybe(run, options = {}) {
   const startCommand = options.start

--- a/tests/basic/README.md
+++ b/tests/basic/README.md
@@ -1,0 +1,6 @@
+# basic test
+
+These tests run:
+- [ ] before the build
+- [x] after the build
+- [ ] on deploy success

--- a/tests/basic/netlify.toml
+++ b/tests/basic/netlify.toml
@@ -6,3 +6,11 @@ publish = "public"
   # local Cypress plugin will test our site after it is built
   # in production, please use: package = "netlify-plugin-cypress"
   package = "../../"
+
+  # do not run tests after deploy (testing)
+  [plugins.inputs]
+    enable = false
+
+  # run tests postBuild
+  [plugins.inputs.postBuild]
+    enable = true

--- a/tests/html-pages/README.md
+++ b/tests/html-pages/README.md
@@ -9,3 +9,8 @@ Test locally with
 ```
 $ DEBUG=netlify-plugin-cypress ../../node_modules/.bin/netlify build
 ```
+
+These tests run:
+- [ ] before the build
+- [x] after the build
+- [ ] on deploy success

--- a/tests/html-pages/netlify.toml
+++ b/tests/html-pages/netlify.toml
@@ -6,3 +6,11 @@ publish = "public"
   # local Cypress plugin will test our site after it is built
   # in production, please use: package = "netlify-plugin-cypress"
   package = "../../"
+
+  # do not run tests after deploy
+  [plugins.inputs]
+    enable = false
+
+  # run and record tests post build
+  [plugins.inputs.postBuild]
+    enable = true

--- a/tests/recommended/README.md
+++ b/tests/recommended/README.md
@@ -1,0 +1,6 @@
+# recommended test
+
+These tests run:
+- [ ] before the build
+- [x] after the build
+- [ ] on deploy success

--- a/tests/recommended/netlify.toml
+++ b/tests/recommended/netlify.toml
@@ -13,3 +13,15 @@ TERM = "xterm"
   # local Cypress plugin will test our site after it is built
   # in production, please use: package = "netlify-plugin-cypress"
   package = "../../"
+
+  # this is a testing situation
+  # in the real system we recommend running tests post deploy
+  # by default and enable preBuild and postBuild if needed
+
+  # do not run tests after deploy (testing)
+  [plugins.inputs]
+    enable = false
+
+  # run tests postBuild
+  [plugins.inputs.postBuild]
+    enable = true

--- a/tests/recording/README.md
+++ b/tests/recording/README.md
@@ -1,0 +1,6 @@
+# recommended test
+
+These tests run:
+- [ ] before the build
+- [x] after the build
+- [ ] on deploy success

--- a/tests/recording/netlify.toml
+++ b/tests/recording/netlify.toml
@@ -13,7 +13,13 @@ TERM = "xterm"
   # local Cypress plugin will test our site after it is built
   # in production, please use: package = "netlify-plugin-cypress"
   package = "../../"
+
+  # do not run tests after deploy
   [plugins.inputs]
+    enable = false
+
+  # run and record tests post build
+  [plugins.inputs.postBuild]
     record = true
     group = "test once after build"
     tag = "recommended"

--- a/tests/recording/netlify.toml
+++ b/tests/recording/netlify.toml
@@ -20,6 +20,7 @@ TERM = "xterm"
 
   # run and record tests post build
   [plugins.inputs.postBuild]
+    enable = true
     record = true
     group = "test once after build"
     tag = "recommended"

--- a/tests/routing/README.md
+++ b/tests/routing/README.md
@@ -5,6 +5,11 @@ This example tests the redirect fallback that makes client-side routing defined 
 
 ![Test screenshot](images/routing.png)
 
+These tests run:
+- [x] before the build
+- [x] after the build
+- [ ] on deploy success
+
 ## Local build
 
-Use command `npm run netlify:build` to try the plugin locally
+Use command `DEBUG=netlify-plugin-cypress npm run netlify:build` to try the plugin locally

--- a/tests/routing/netlify.toml
+++ b/tests/routing/netlify.toml
@@ -8,6 +8,8 @@ publish = "build"
 CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"
 # set TERM variable for terminal output
 TERM = "xterm"
+# do not print too many progress messages
+CI = "1"
 
 [[plugins]]
   # local Cypress plugin will test our site after it is built
@@ -17,15 +19,22 @@ TERM = "xterm"
   # run Cypress tests once on the site before it is built
   # and then after building the static folder
 
+  [plugins.inputs]
+    # these settings apply to the default step onSuccess
+    # in this case, we do not want to run any tests after deploy
+    enable = false
+
   # let's run tests against development server
   # before building it (and testing the built site)
   [plugins.inputs.preBuild]
+    enable = true
     start = 'npm start'
     wait-on = 'http://localhost:3000'
     wait-on-timeout = '45' # seconds
 
   # and test the built site after
-  [plugins.inputs]
+  [plugins.inputs.postBuild]
+    enable = true
     # must allow our test server to redirect unknown routes to "/"
     # so that client-side routing can correctly route them
     # can be set to true or "index.html" (or similar fallback filename in the built folder)

--- a/tests/test-netlify-dev/README.md
+++ b/tests/test-netlify-dev/README.md
@@ -1,0 +1,10 @@
+# use Netlify dev command
+
+These tests run:
+- [x] before the build
+- [ ] after the build
+- [ ] on deploy success
+
+## Local build
+
+Use command `DEBUG=netlify-plugin-cypress npm run netlify:build` to try the plugin locally

--- a/tests/test-netlify-dev/netlify.toml
+++ b/tests/test-netlify-dev/netlify.toml
@@ -12,6 +12,8 @@ functions = "src/functions"
 CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"
 # set TERM variable for terminal output
 TERM = "xterm"
+# do not print too many progress messages
+CI = "1"
 
 [dev]
   command = "npx serve public"
@@ -32,9 +34,10 @@ TERM = "xterm"
   # and Netlify functions
   # let's run tests against Netlify Dev server
   [plugins.inputs.preBuild]
+    enable = true
     start = 'npx netlify dev'
     wait-on = 'http://localhost:8888'
 
-  # and skip tests after building it
+  # do no run tests after deploy
   [plugins.inputs]
-    skip = true
+    enable = false

--- a/tests/test-netlify-dev/package.json
+++ b/tests/test-netlify-dev/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "prebuild-only-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "netlify:build": "../../node_modules/.bin/netlify build"
+  }
+}

--- a/tests/test-prebuild-only/README.md
+++ b/tests/test-prebuild-only/README.md
@@ -1,0 +1,10 @@
+# run pre-build tests only
+
+These tests run:
+- [x] before the build
+- [ ] after the build
+- [ ] on deploy success
+
+## Local build
+
+Use command `DEBUG=netlify-plugin-cypress npm run netlify:build` to try the plugin locally

--- a/tests/test-prebuild-only/netlify.toml
+++ b/tests/test-prebuild-only/netlify.toml
@@ -8,6 +8,8 @@ publish = "public"
 CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"
 # set TERM variable for terminal output
 TERM = "xterm"
+# do not print too many progress messages
+CI = "1"
 
 [[plugins]]
   # local Cypress plugin will test our site after it is built
@@ -17,12 +19,14 @@ TERM = "xterm"
   # run Cypress tests once on the site before it is built
   # and do not run the tests after it was built
 
+  [plugins.inputs]
+    # these settings apply to the default step onSuccess
+    # in this case, we do not want to run any tests after deploy
+    enable = false
+
   # let's run tests against development server
   [plugins.inputs.preBuild]
+    enable = true
     start = 'npx serve public'
     wait-on = 'http://localhost:5000'
     wait-on-timeout = '30' # seconds
-
-  # and skip tests after building it
-  [plugins.inputs]
-    skip = true

--- a/tests/test-prebuild-only/package.json
+++ b/tests/test-prebuild-only/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "prebuild-only-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "netlify:build": "../../node_modules/.bin/netlify build"
+  }
+}

--- a/tests/test-twice/README.md
+++ b/tests/test-twice/README.md
@@ -1,0 +1,15 @@
+# routing example
+> Client-side routing with fallback
+
+This example tests the redirect fallback that makes client-side routing defined in [src/App.js](src/App.js) work. See [netlify.toml](netlify.toml)
+
+![Test screenshot](images/routing.png)
+
+These tests run:
+- [x] before the build
+- [x] after the build
+- [ ] on deploy success
+
+## Local build
+
+Use command `DEBUG=netlify-plugin-cypress npm run netlify:build` to try the plugin locally

--- a/tests/test-twice/netlify.toml
+++ b/tests/test-twice/netlify.toml
@@ -17,9 +17,14 @@ TERM = "xterm"
   # run Cypress tests once on the site before it is built
   # and then after building the static folder
 
+  # do not run tests after deploy
+  [plugins.inputs]
+    enable = false
+
   # let's run tests against development server
   # before building it (and testing the built site)
   [plugins.inputs.preBuild]
+    enable = true
     start = 'npx serve public'
     wait-on = 'http://localhost:5000'
     wait-on-timeout = '30' # seconds
@@ -27,8 +32,8 @@ TERM = "xterm"
     group = "test twice: 1 - before build"
     tag = "test twice"
 
-  # and test after
-  [plugins.inputs]
+  # and test after build
+  [plugins.inputs.postBuild]
     record = true
     group = "test twice: 2 - after build"
     tag = "test twice"

--- a/tests/use-chromium/README.md
+++ b/tests/use-chromium/README.md
@@ -1,0 +1,6 @@
+# use Chromium browser
+
+These tests run:
+- [ ] before the build
+- [x] after the build
+- [ ] on deploy success

--- a/tests/use-chromium/netlify.toml
+++ b/tests/use-chromium/netlify.toml
@@ -6,5 +6,12 @@ publish = "public"
   # local Cypress plugin will test our site after it is built
   # in production, please use: package = "netlify-plugin-cypress"
   package = "../../"
+
   [plugins.inputs]
+    # do not run tests after deploy
+    enable = false
+
+  # only run tests postBuild before deploy
+  [plugins.inputs.postBuild]
+    enable = true
     browser = "chromium"


### PR DESCRIPTION
BREAKING CHANGE: now the onSuccess step is the default testing
step, running the Cypress tests against the preview or production
deploy. Another change is the default browser is Chromium instead
of Electron.

- closes #130
- [x] README updated
- [x] default browser is Chromium
- [x] default test step is onSuccess
- [x] all test cases are updated
- [x] netlify-plugin-cypress-example works https://github.com/cypress-io/netlify-plugin-cypress-example/pull/71
- [x] netlify-plugin-prebuild-example works https://github.com/cypress-io/netlify-plugin-prebuild-example/pull/50
- [x] cypress-example-kitchensink works https://github.com/cypress-io/cypress-example-kitchensink/pull/472
- [x] bahmutov/eleventyone works https://github.com/bahmutov/eleventyone/pull/11
- [x] gatsby-starter-portfolio-cara https://github.com/bahmutov/gatsby-starter-portfolio-cara/pull/1

## After merging and publishing the new NPM version

- update each example project and merge the new version!