### PR TITLE
Allow configuring using DEPLOY_URL instead of DEPLOY_PRIME_URL

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -46,3 +46,9 @@ inputs:
   # NOTE: does not execute Netlify API redirects or functions
   - name: postBuild
     description: Run tests against the built static site
+
+  # See Netlify docs for available values:
+  # https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata
+  - name: deployUrlEnvVar
+    description: The Netlify environment variable containing the URL Cypress should test
+    default: DEPLOY_PRIME_URL

--- a/src/onSuccess.js
+++ b/src/onSuccess.js
@@ -18,10 +18,10 @@ module.exports = async ({ utils, inputs, constants }) => {
 
   const isLocal = constants.IS_LOCAL
   const siteName = process.env.SITE_NAME
-  const deployPrimeUrl = process.env.DEPLOY_PRIME_URL
+  const deployUrl = process.env[onSuccessInputs.deployUrlEnvVar]
   debug('onSuccess against %o', {
     siteName,
-    deployPrimeUrl,
+    deployUrl,
     isLocal,
   })
 
@@ -36,8 +36,8 @@ module.exports = async ({ utils, inputs, constants }) => {
   const errorCallback = utils.build.failPlugin.bind(utils.build)
   const summaryCallback = utils.status.show.bind(utils.status)
 
-  if (!deployPrimeUrl) {
-    return errorCallback('Missing DEPLOY_PRIME_URL')
+  if (!deployUrl) {
+    return errorCallback('Missing deployUrl')
   }
 
   const browser = onSuccessInputs.browser || DEFAULT_BROWSER
@@ -69,9 +69,9 @@ module.exports = async ({ utils, inputs, constants }) => {
 
   const configFile = onSuccessInputs.configFile
 
-  console.log('testing deployed url %s', deployPrimeUrl)
+  console.log('testing deployed url %s', deployUrl)
   const results = await runCypressTests(
-    deployPrimeUrl,
+    deployUrl,
     record,
     spec,
     group,


### PR DESCRIPTION
Hello!
We would like to use Netlify's `DEPLOY_URL` environment variable as our Cypress testing URL, as opposed to the hardcoded `DEPLOY_PRIME_URL`.
This PR adds a new `deployUrlEnvVar` plugin input, which defaults to `DEPLOY_PRIME_URL` but should allow overriding with `DEPLOY_URL`